### PR TITLE
Rename Osmosis Staking platform to Cosmos SDK

### DIFF
--- a/cms/earn/strategies.json
+++ b/cms/earn/strategies.json
@@ -3,7 +3,7 @@
     {
       "id": "osmo-staking",
       "name": "OSMO Staking",
-      "platform": "Cosmos SDK (Staking Module on Osmosis)",
+      "platform": "Cosmos SDK",
       "category": "Staking",
       "type": "osmosis-staking",
       "link": "https://app.osmosis.zone/stake",


### PR DESCRIPTION
Rename Osmosis Staking platform to Cosmos SDK
so it can be used by all chains.