### PR TITLE
Add Landing Page CMS for Upcoming Assets

### DIFF
--- a/cms/landing-page/README.md
+++ b/cms/landing-page/README.md
@@ -1,0 +1,57 @@
+# Landing Page
+
+Welcome to the Landing Page CMS! This repository contains a JSON schema for structuring landing page content. We welcome contributions from the community to help improve the CMS and keep the content up to date.
+
+## Overview
+
+The Landing Page CMS is designed to organize content for the Osmosis Zone landing page. It utilizes a JSON schema to define the structure of the content, ensuring consistency and ease of use.
+
+### Upcoming Assets
+
+Currently, the only data maintained in this CMS is the Upcoming Assets. Assets shown here should be valuable and strategic for visitors to see.
+Upcoming assets should only include assets launching within the next month, and have a plan for asset integration, as well as substanital market making. 
+
+## Schema
+
+### Properties
+
+The Landing Page schema includes the following properties:
+
+- `upcomingAssets`: An array of assets containing information about each asset.
+  - `assetName`: The name of the asset.
+  - `symbol`: The symbol of the asset.
+  - `chainName`: The name of the blockchain or network where the asset originates.
+  - `logoURL`: The URL to the logo image of the asset. It must be hosted on the Cosmos chain registry master and have a `.png` or `.svg` extension.
+  - `estimatedLaunchDateUtc`: The estimated launch date and time (UTC) of the asset.
+  - `osmosisAirdrop`: Indicates whether Osmosis Stakers or LPs are eligible for an airdrop of the asset.
+
+### Example
+
+Here's an example of how content can be structured using the Landing Page schema:
+
+```json
+{
+  "upcoming_assets": [
+    {
+      "assetName": "Osmosis",
+      "symbol": "OSMO",
+      "chainName": "Osmosis",
+      "logoURL": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
+      "estimatedLaunchDateUtc": "2049-01-01T01:01:01Z",
+      "osmosisAirdrop": false
+    },
+    {
+      "assetName": "Celestia",
+      "symbol": "TIA",
+      "chainName": "Celstia",
+      "logoURL": "https://raw.githubusercontent.com/cosmos/chain-registry/master/celestia/images/tia.png",
+      "estimatedLaunchDateUtc": "2049-01-01T01:01:01Z",
+      "osmosisAirdrop": true
+    }
+  ]
+}
+```
+
+## Contributing
+
+Contributions to the schema are welcome. If you identify any issues, have suggestions for improvements, or wish to contribute enhancements, feel free to open an issue or submit a pull request.

--- a/cms/landing-page/landing-page.json
+++ b/cms/landing-page/landing-page.json
@@ -1,0 +1,12 @@
+{
+  "upcomingAssets": [
+    {
+      "assetName": "Osmosis",
+      "symbol": "OSMO",
+      "chainName": "Osmosis",
+      "logoURL": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
+      "estimatedLaunchDateUtc": "2049-01-01T01:01:01Z",
+      "osmosisAirdrop": false
+    }
+  ]
+}

--- a/schemas/landing-page.schema.json
+++ b/schemas/landing-page.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "assets": {
+    "upcomingAssets": {
       "type": "array",
       "items": {
         "type": "object",
@@ -45,5 +45,5 @@
       }
     }
   },
-  "required": ["assets"]
+  "required": ["upcomingAssets"]
 }

--- a/schemas/landing-page.schema.json
+++ b/schemas/landing-page.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "assets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "assetName": {
+            "type": "string",
+            "description": "The name of the asset.",
+            "example": "Osmosis"
+          },
+          "symbol": {
+            "type": "string",
+            "description": "The symbol of the asset.",
+            "example": "OSMO"
+          },
+          "chainName": {
+            "type": "string",
+            "description": "The name of the blockchain or network where the asset originates.",
+            "example": "Osmosis"
+          },
+          "logoURL": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL to the logo image of the asset.",
+            "example": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png"
+            "pattern": "^https://raw.githubusercontent.com/cosmos/chain-registry/master/.+\\.png$"
+          },
+          "estimatedLaunchDateUtc": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}Z)?$",
+            "example": "2049-01-01T01:01:01Z",
+            "description": "The estimated launch date and time (UTC) of the asset."
+          },
+          "osmosisAirdrop": {
+            "type": "boolean",
+            "description": "Indicates whether Osmosis Stakers or LPs are eligible for an airdrop of the asset.",
+            "example": false
+          }
+        },
+        "required": ["assetName", "symbol", "chainName", "logoURL", "estimatedLaunchDateUtc", "osmosisAirdrop"]
+      }
+    }
+  },
+  "required": ["assets"]
+}


### PR DESCRIPTION
Add Landing Page CMS for Upcoming Assets
Defines a schema, a readme, and a data file with OSMO as an example.
TODO - Populate the file with actual upcoming tokens