### PR TITLE
Minor Earn Data Fixes

### DIFF
--- a/cms/earn/strategies.json
+++ b/cms/earn/strategies.json
@@ -1891,8 +1891,8 @@
       "category": "Lending",
       "type": "mars-lending",
       "link": "https://app.marsprotocol.io",
-      "tvl": "https://public-osmosis-api.numia.xyz/earn/strategies/factory-osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA-mars/tvl",
-      "apr": "https://public-osmosis-api.numia.xyz/earn/strategies/factory-osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA-mars/apr",
+      "tvl": "https://public-osmosis-api.numia.xyz/earn/strategies/factory-osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0%2fumilkTIA-mars/tvl",
+      "apr": "https://public-osmosis-api.numia.xyz/earn/strategies/factory-osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0%2fumilkTIA-mars/apr",
       "geoblock": "https://geoblocked.levana.finance/",
       "lockDuration": "PT0S",
       "riskLevel": 0.01,
@@ -2270,13 +2270,13 @@
       "link": "https://app.marsprotocol.io",
       "tvl": "https://public-osmosis-api.numia.xyz/earn/strategies/ibc-D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877-mars/tvl",
       "apr": "https://public-osmosis-api.numia.xyz/earn/strategies/ibc-D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877-mars/apr",
-      "geoblock": "The deposited asset is lent to borrowers.",
+      "geoblock": "https://geoblocked.levana.finance/",
       "lockDuration": "PT0S",
       "riskLevel": 0.01,
       "startDateTimeUtc": "2021-06-01T01:01:01Z",
       "unlisted": false,
       "disabled": false,
-      "message": "",
+      "message": "The deposited asset is lent to borrowers.",
       "depositDenoms": [
         {
           "coinMinimalDenom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877"

--- a/schemas/strategies.schema.json
+++ b/schemas/strategies.schema.json
@@ -47,16 +47,7 @@
           "link": {
             "type": "string",
             "format": "uri",
-            "oneOf": [
-              {
-                "type": "string",
-                "pattern": "^https:\/\/.*$"
-              },
-              {
-                "type": "string",
-                "maxLength": 0
-              }
-            ],
+            "pattern": "^https:\/\/.*$",
             "description": "This link redirects users to the most appropriate interface for users participate in the strategy."
           },
           "contract": {
@@ -97,16 +88,7 @@
           "geoblock": {
             "type": "string",
             "format": "uri",
-            "oneOf": [
-              {
-                "type": "string",
-                "pattern": "^https:\/\/.*$"
-              },
-              {
-                "type": "string",
-                "maxLength": 0
-              }
-            ],
+            "pattern": "^https:\/\/.*$",
             "description": "A URL to the data endpoint for a list of regions that are geographically restricted by the primany interface provider. The response must match how it's defined in the documentation."
           },
           "lockDuration": {

--- a/schemas/strategies.schema.json
+++ b/schemas/strategies.schema.json
@@ -47,6 +47,16 @@
           "link": {
             "type": "string",
             "format": "uri",
+            "oneOf": [
+              {
+                "type": "string",
+                "pattern": "^https:\/\/.*$"
+              },
+              {
+                "type": "string",
+                "maxLength": 0
+              }
+            ],
             "description": "This link redirects users to the most appropriate interface for users participate in the strategy."
           },
           "contract": {
@@ -57,16 +67,46 @@
           "tvl": {
             "type": "string",
             "format": "uri",
+            "oneOf": [
+              {
+                "type": "string",
+                "pattern": "^https:\/\/.*$"
+              },
+              {
+                "type": "string",
+                "maxLength": 0
+              }
+            ],
             "description": "A URL to the data endpoint for the Total Value Locked (TVL) of the strategy. The response must match how it's defined in the documentation."
           },
           "apr": {
             "type": "string",
             "format": "uri",
+            "oneOf": [
+              {
+                "type": "string",
+                "pattern": "^https:\/\/.*$"
+              },
+              {
+                "type": "string",
+                "maxLength": 0
+              }
+            ],
             "description": "A URL to the data endpoint for the Annual Percentage Rate (APR) of the strategy. The response must match how it's defined in the documentation."
           },
           "geoblock": {
             "type": "string",
             "format": "uri",
+            "oneOf": [
+              {
+                "type": "string",
+                "pattern": "^https:\/\/.*$"
+              },
+              {
+                "type": "string",
+                "maxLength": 0
+              }
+            ],
             "description": "A URL to the data endpoint for a list of regions that are geographically restricted by the primany interface provider. The response must match how it's defined in the documentation."
           },
           "lockDuration": {

--- a/schemas/strategies.schema.json
+++ b/schemas/strategies.schema.json
@@ -88,7 +88,16 @@
           "geoblock": {
             "type": "string",
             "format": "uri",
-            "pattern": "^https:\/\/.*$",
+            "oneOf": [
+              {
+                "type": "string",
+                "pattern": "^https:\/\/.*$"
+              },
+              {
+                "type": "string",
+                "maxLength": 0
+              }
+            ],
             "description": "A URL to the data endpoint for a list of regions that are geographically restricted by the primany interface provider. The response must match how it's defined in the documentation."
           },
           "lockDuration": {


### PR DESCRIPTION
Minor Earn Data Fixes

Replaces URL / with encoded %2f where mars milktia ID has a slash in it.
Moved a message that was mistakenly in the "geoblock" property.