### PR TITLE
Update Landing Page Upcoming Date to String

### DIFF
--- a/cms/landing-page/README.md
+++ b/cms/landing-page/README.md
@@ -22,7 +22,7 @@ The Landing Page schema includes the following properties:
   - `symbol`: The symbol of the asset.
   - `chainName`: The name of the blockchain or network where the asset originates.
   - `logoURL`: The URL to the logo image of the asset. It must be hosted on the Cosmos chain registry master and have a `.png` or `.svg` extension.
-  - `estimatedLaunchDateUtc`: The estimated launch date and time (UTC) of the asset.
+  - `estimatedLaunchDate`: The estimated launch date of the asset. May be precise to the day (e.g., March 24, 2024) or to the quarter (e.g., Q3 2023). 
   - `osmosisAirdrop`: Indicates whether Osmosis Stakers or LPs are eligible for an airdrop of the asset.
 
 ### Example
@@ -37,7 +37,7 @@ Here's an example of how content can be structured using the Landing Page schema
       "symbol": "OSMO",
       "chainName": "Osmosis",
       "logoURL": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
-      "estimatedLaunchDateUtc": "2049-01-01T01:01:01Z",
+      "estimatedLaunchDateUtc": "January 1, 2049",
       "osmosisAirdrop": false
     },
     {
@@ -45,7 +45,7 @@ Here's an example of how content can be structured using the Landing Page schema
       "symbol": "TIA",
       "chainName": "Celstia",
       "logoURL": "https://raw.githubusercontent.com/cosmos/chain-registry/master/celestia/images/tia.png",
-      "estimatedLaunchDateUtc": "2049-01-01T01:01:01Z",
+      "estimatedLaunchDateUtc": "Q3 2023",
       "osmosisAirdrop": true
     }
   ]

--- a/cms/landing-page/README.md
+++ b/cms/landing-page/README.md
@@ -22,7 +22,7 @@ The Landing Page schema includes the following properties:
   - `symbol`: The symbol of the asset.
   - `chainName`: The name of the blockchain or network where the asset originates.
   - `logoURL`: The URL to the logo image of the asset. It must be hosted on the Cosmos chain registry master and have a `.png` or `.svg` extension.
-  - `estimatedLaunchDate`: The estimated launch date of the asset. May be precise to the day (e.g., March 24, 2024) or to the quarter (e.g., Q3 2023). 
+  - `estimatedLaunchDate`: The estimated launch date of the asset. May be precise to the day (e.g., Mar 24, 2024) or to the quarter (e.g., Q3 2023). 
   - `osmosisAirdrop`: Indicates whether Osmosis Stakers or LPs are eligible for an airdrop of the asset.
 
 ### Example
@@ -37,7 +37,7 @@ Here's an example of how content can be structured using the Landing Page schema
       "symbol": "OSMO",
       "chainName": "Osmosis",
       "logoURL": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
-      "estimatedLaunchDateUtc": "January 1, 2049",
+      "estimatedLaunchDateUtc": "Jan 1, 2049",
       "osmosisAirdrop": false
     },
     {

--- a/cms/landing-page/landing-page.json
+++ b/cms/landing-page/landing-page.json
@@ -5,7 +5,7 @@
       "symbol": "W",
       "chainName": "Wormhole Gateway",
       "logoURL": "https://raw.githubusercontent.com/osmosis-labs/fe-content/main/cms/landing-page/images/w.png",
-      "estimatedLaunchDateUtc": "2024-03-20T00:00:00Z",
+      "estimatedLaunchDateUtc": "March 2024",
       "showLaunchDate": false,
       "osmosisAirdrop": false
     },
@@ -14,7 +14,7 @@
       "symbol": "TNKR",
       "chainName": "Tinkernet",
       "logoURL": "https://raw.githubusercontent.com/osmosis-labs/fe-content/main/cms/landing-page/images/tnkr.png",
-      "estimatedLaunchDateUtc": "2024-03-25T00:00:00Z",
+      "estimatedLaunchDateUtc": "March 2024",
       "showLaunchDate": false,
       "osmosisAirdrop": false
     },
@@ -23,7 +23,7 @@
       "symbol": "SAGA",
       "chainName": "Saga",
       "logoURL": "https://raw.githubusercontent.com/cosmos/chain-registry/master/saga/images/saga.png",
-      "estimatedLaunchDateUtc": "2024-04-07T00:00:00Z",
+      "estimatedLaunchDateUtc": "April 2024",
       "showLaunchDate": false,
       "osmosisAirdrop": false
     },
@@ -32,7 +32,7 @@
       "symbol": "ANDR",
       "chainName": "Andromeda",
       "logoURL": "https://raw.githubusercontent.com/cosmos/chain-registry/master/andromeda/images/andromeda-logo.png",
-      "estimatedLaunchDateUtc": "2024-04-15T00:00:00Z",
+      "estimatedLaunchDateUtc": "April 2024",
       "showLaunchDate": false,
       "osmosisAirdrop": false
     },
@@ -41,7 +41,7 @@
       "symbol": "AVAIL",
       "chainName": "Avail",
       "logoURL": "https://raw.githubusercontent.com/osmosis-labs/fe-content/main/cms/landing-page/images/avail_logo_icon3x-1.svg",
-      "estimatedLaunchDateUtc": "2024-04-10T00:00:00Z",
+      "estimatedLaunchDateUtc": "April 2024",
       "showLaunchDate": false,
       "osmosisAirdrop": false
     }

--- a/cms/landing-page/landing-page.json
+++ b/cms/landing-page/landing-page.json
@@ -5,7 +5,7 @@
       "symbol": "W",
       "chainName": "Wormhole Gateway",
       "logoURL": "https://raw.githubusercontent.com/osmosis-labs/fe-content/main/cms/landing-page/images/w.png",
-      "estimatedLaunchDateUtc": "March 2024",
+      "estimatedLaunchDateUtc": "Mar 2024",
       "showLaunchDate": false,
       "osmosisAirdrop": false
     },
@@ -14,7 +14,7 @@
       "symbol": "TNKR",
       "chainName": "Tinkernet",
       "logoURL": "https://raw.githubusercontent.com/osmosis-labs/fe-content/main/cms/landing-page/images/tnkr.png",
-      "estimatedLaunchDateUtc": "March 2024",
+      "estimatedLaunchDateUtc": "Mar 2024",
       "showLaunchDate": false,
       "osmosisAirdrop": false
     },
@@ -23,7 +23,7 @@
       "symbol": "SAGA",
       "chainName": "Saga",
       "logoURL": "https://raw.githubusercontent.com/cosmos/chain-registry/master/saga/images/saga.png",
-      "estimatedLaunchDateUtc": "April 2024",
+      "estimatedLaunchDateUtc": "Apr 2024",
       "showLaunchDate": false,
       "osmosisAirdrop": false
     },
@@ -32,7 +32,7 @@
       "symbol": "ANDR",
       "chainName": "Andromeda",
       "logoURL": "https://raw.githubusercontent.com/cosmos/chain-registry/master/andromeda/images/andromeda-logo.png",
-      "estimatedLaunchDateUtc": "April 2024",
+      "estimatedLaunchDateUtc": "Apr 2024",
       "showLaunchDate": false,
       "osmosisAirdrop": false
     },
@@ -41,7 +41,7 @@
       "symbol": "AVAIL",
       "chainName": "Avail",
       "logoURL": "https://raw.githubusercontent.com/osmosis-labs/fe-content/main/cms/landing-page/images/avail_logo_icon3x-1.svg",
-      "estimatedLaunchDateUtc": "April 2024",
+      "estimatedLaunchDateUtc": "Apr 2024",
       "showLaunchDate": false,
       "osmosisAirdrop": false
     }

--- a/schemas/landing-page.schema.json
+++ b/schemas/landing-page.schema.json
@@ -29,11 +29,11 @@
             "pattern": "^https://raw.githubusercontent.com\/.+\\.(png|svg)$",
             "example": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png"
           },
-          "estimatedLaunchDateUtc": {
+          "estimatedLaunchDate": {
             "type": "string",
-            "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}Z)?$",
-            "example": "2049-01-01T01:01:01Z",
-            "description": "The estimated launch date and time (UTC) of the asset."
+            "pattern": "^(Q[1-4]|((January|February|March|April|May|June|July|August|September|October|November|December)(\\s\\d{1,2},)?))?\\s\\d{4}$",
+            "description": "The estimated launch date of the asset. Accepts dates in the formats: month name + year (e.g., March 2024), month name + day + year (e.g., March 22, 2024), and quarter + year (e.g., Q2 2024)."
+            "example": "March 22, 2024",
           },
           "showLaunchDate": {
             "type": "boolean",

--- a/schemas/landing-page.schema.json
+++ b/schemas/landing-page.schema.json
@@ -32,8 +32,8 @@
           "estimatedLaunchDate": {
             "type": "string",
             "pattern": "^(Q[1-4]|((January|February|March|April|May|June|July|August|September|October|November|December)(\\s\\d{1,2},)?))?\\s\\d{4}$",
-            "description": "The estimated launch date of the asset. Accepts dates in the formats: month name + year (e.g., March 2024), month name + day + year (e.g., March 22, 2024), and quarter + year (e.g., Q2 2024)."
-            "example": "March 22, 2024",
+            "description": "The estimated launch date of the asset. Accepts dates in the formats: month name + year (e.g., March 2024), month name + day + year (e.g., March 22, 2024), and quarter + year (e.g., Q2 2024).",
+            "example": "March 22, 2024"
           },
           "showLaunchDate": {
             "type": "boolean",

--- a/schemas/landing-page.schema.json
+++ b/schemas/landing-page.schema.json
@@ -31,7 +31,7 @@
           },
           "estimatedLaunchDate": {
             "type": "string",
-            "pattern": "^(Q[1-4]|((January|February|March|April|May|June|July|August|September|October|November|December)(\\s\\d{1,2},)?))?\\s\\d{4}$",
+            "pattern": "^(Q[1-4]|((Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)(\\s\\d{1,2},)?))?\\s\\d{4}$",
             "description": "The estimated launch date of the asset. Accepts dates in the formats: month name + year (e.g., March 2024), month name + day + year (e.g., March 22, 2024), and quarter + year (e.g., Q2 2024).",
             "example": "March 22, 2024"
           },


### PR DESCRIPTION
Update Landing Page Upcoming Date to String
instead of ISO 8601 datetime.
The precision was limiting.

New accepted formats:
"Q3 2024"
"March 2024"
"March 24, 2024"
