### PR TITLE
feat(alerts): asset alerts CMS with BitFrost bridge sunset notice

### DIFF
--- a/__tests__/validate-asset-alerts.spec.js
+++ b/__tests__/validate-asset-alerts.spec.js
@@ -1,0 +1,19 @@
+import fs from "fs";
+import { expect, test } from "vitest";
+
+// Draft-07 JSON schema cannot express cross-field comparisons, so the
+// startDate/endDate relationship is enforced here instead.
+const { alerts } = JSON.parse(
+  fs.readFileSync("./cms/asset-alerts.json", "utf8")
+);
+
+test("asset alert date windows end after they start", () => {
+  alerts.forEach(({ banner: { localStorageKey, startDate, endDate } }) => {
+    if (startDate && endDate) {
+      expect(
+        new Date(endDate) > new Date(startDate),
+        `${localStorageKey}: endDate must be after startDate`
+      ).toBe(true);
+    }
+  });
+});

--- a/cms/asset-alerts.json
+++ b/cms/asset-alerts.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "../schemas/asset-alerts.schema.json",
+  "alerts": [
+    {
+      "denoms": [
+        "ibc/7D29C888219883C47C623578ACACFC89CC29AA70FBF09C895A1EED911BF90F32",
+        "ibc/B3DFDC2958A2BE482532DA3B6B5729B469BE7475598F7487D98B1B3E085245DE",
+        "ibc/2F4258D6E1E01B203D6CA83F2C7E4959615053A21EC2C2FC196F7911CAC832EF",
+        "ibc/869E01805EBBDDCAEA588666CD5149728B7DC7D69F30D92F77AD67F77CEB3FDA",
+        "ibc/905326586AE1C86AC8B1CDB20BE957DE5FB23963EDD2C9ADD3E835CC22115A46",
+        "ibc/DDE1238DCBC338C0FD0700A72CBD64C017B7A646C4A46789ADFB5D47F1E52E38",
+        "ibc/A1465DD6AF456FCD0D998869608DFEEDA4F4C11EC0A12AF92A994A3F8CBEE546",
+        "ibc/013DE940BE791C79142EAD4DF071E1ED280DFEAB8A9DCB5932A4603A74C25CBB",
+        "ibc/2C5CB5DB3D86F64FDE6155A3A94D7543A126DA55490309EEDF59A0765873DA1C",
+        "ibc/51BFF64A432CBBA08A1ED95609BF0255EC4BBF699BFCDFF267F66CCD664CA350",
+        "ibc/18A91A3DDFD9776A247AE1B4B3298D754D1627B85F288DCEA473B7239F7B7A0E"
+      ],
+      "banner": {
+        "enTextOrLocalizationPath": "header",
+        "localStorageKey": "bitfrost-int3face-sunset",
+        "link": {
+          "enTextOrLocalizationKey": "link",
+          "url": "https://x.com/_Bitfrost_/status/2082826447073300616",
+          "isExternal": true
+        },
+        "isWarning": true,
+        "startDate": "2026-07-30T00:00:00Z",
+        "endDate": "2026-08-12T23:59:59Z"
+      },
+      "localization": {
+        "de": {
+          "header": "Die BitFrost-Brücke (Int3face) wird eingestellt: Ziehe deine {symbols}-Liquidität ab und bridge deine Assets bis zum 12. August 2026.",
+          "link": "Mehr erfahren"
+        },
+        "en": {
+          "header": "The BitFrost (Int3face) bridge is winding down: withdraw your {symbols} liquidity and bridge out before August 12, 2026.",
+          "link": "Learn more"
+        },
+        "es": {
+          "header": "El puente BitFrost (Int3face) se está cerrando: retira tu liquidez de {symbols} y transfiere tus activos antes del 12 de agosto de 2026.",
+          "link": "Más información"
+        },
+        "fa": {
+          "header": "پل BitFrost (Int3face) در حال توقف است: نقدینگی {symbols} خود را برداشت کرده و دارایی‌های خود را تا ۱۲ اوت ۲۰۲۶ منتقل کنید.",
+          "link": "اطلاعات بیشتر"
+        },
+        "fr": {
+          "header": "Le pont BitFrost (Int3face) prend fin : retirez votre liquidité {symbols} et transférez vos actifs avant le 12 août 2026.",
+          "link": "En savoir plus"
+        },
+        "gu": {
+          "header": "BitFrost (Int3face) બ્રિજ બંધ થઈ રહ્યો છે: તમારી {symbols} લિક્વિડિટી પાછી ખેંચો અને 12 ઓગસ્ટ 2026 પહેલાં તમારી સંપત્તિ બ્રિજ કરો.",
+          "link": "વધુ જાણો"
+        },
+        "hi": {
+          "header": "BitFrost (Int3face) ब्रिज बंद हो रहा है: अपनी {symbols} लिक्विडिटी निकालें और 12 अगस्त 2026 से पहले अपनी संपत्ति ब्रिज करें।",
+          "link": "अधिक जानें"
+        },
+        "ja": {
+          "header": "BitFrost（Int3face）ブリッジはサービス終了となります。2026年8月12日までに{symbols}の流動性を引き出し、資産をブリッジしてください。",
+          "link": "詳細はこちら"
+        },
+        "ko": {
+          "header": "BitFrost(Int3face) 브리지 서비스가 종료됩니다. 2026년 8월 12일까지 {symbols} 유동성을 인출하고 자산을 브리지하세요.",
+          "link": "자세히 보기"
+        },
+        "pl": {
+          "header": "Most BitFrost (Int3face) jest wycofywany: wycofaj płynność {symbols} i przenieś swoje aktywa do 12 sierpnia 2026 r.",
+          "link": "Dowiedz się więcej"
+        },
+        "pt-br": {
+          "header": "A ponte BitFrost (Int3face) está sendo encerrada: retire sua liquidez de {symbols} e transfira seus ativos até 12 de agosto de 2026.",
+          "link": "Saiba mais"
+        },
+        "ro": {
+          "header": "Podul BitFrost (Int3face) se închide: retrage-ți lichiditatea {symbols} și transferă-ți activele până la 12 august 2026.",
+          "link": "Află mai multe"
+        },
+        "ru": {
+          "header": "Мост BitFrost (Int3face) прекращает работу: выведите ликвидность {symbols} и переведите активы до 12 августа 2026 г.",
+          "link": "Подробнее"
+        },
+        "tr": {
+          "header": "BitFrost (Int3face) köprüsü kullanımdan kaldırılıyor: {symbols} likiditenizi çekin ve varlıklarınızı 12 Ağustos 2026'ya kadar köprüden geçirin.",
+          "link": "Daha fazla bilgi"
+        },
+        "zh-cn": {
+          "header": "BitFrost（Int3face）跨链桥即将停止服务：请在2026年8月12日前提取您的 {symbols} 流动性并将资产跨链转出。",
+          "link": "了解更多"
+        },
+        "zh-hk": {
+          "header": "BitFrost（Int3face）跨鏈橋即將停止服務：請於2026年8月12日前提取您的 {symbols} 流動性並將資產跨鏈轉出。",
+          "link": "了解更多"
+        },
+        "zh-tw": {
+          "header": "BitFrost（Int3face）跨鏈橋即將停止服務：請於2026年8月12日前提取您的 {symbols} 流動性並將資產跨鏈轉出。",
+          "link": "了解更多"
+        }
+      }
+    }
+  ]
+}

--- a/cms/asset-alerts.json
+++ b/cms/asset-alerts.json
@@ -30,75 +30,75 @@
         },
         "isWarning": true,
         "startDate": "2026-07-30T00:00:00Z",
-        "endDate": "2026-08-12T23:59:59Z"
+        "endDate": "2026-08-10T23:59:59Z"
       },
       "localization": {
         "de": {
-          "header": "Die BitFrost-Brücke (Int3face) wird eingestellt: Ziehe deine {symbols}-Liquidität ab und bridge deine Assets bis zum 12. August 2026.",
+          "header": "Die BitFrost-Brücke (Int3face) wird eingestellt: Ziehe gegebenenfalls deine {symbols}-Liquidität ab und bridge deine Assets bis zum 10. August 2026.",
           "link": "Mehr erfahren"
         },
         "en": {
-          "header": "The BitFrost (Int3face) bridge is winding down: withdraw your {symbols} liquidity and bridge out before August 12, 2026.",
+          "header": "The BitFrost (Int3face) bridge is winding down: withdraw {symbols} liquidity if applicable, then bridge your assets out before August 10, 2026.",
           "link": "Learn more"
         },
         "es": {
-          "header": "El puente BitFrost (Int3face) se está cerrando: retira tu liquidez de {symbols} y transfiere tus activos antes del 12 de agosto de 2026.",
+          "header": "El puente BitFrost (Int3face) se está cerrando: retira tu liquidez de {symbols} si corresponde y transfiere tus activos antes del 10 de agosto de 2026.",
           "link": "Más información"
         },
         "fa": {
-          "header": "پل BitFrost (Int3face) در حال توقف است: نقدینگی {symbols} خود را برداشت کرده و دارایی‌های خود را تا ۱۲ اوت ۲۰۲۶ منتقل کنید.",
+          "header": "پل BitFrost (Int3face) در حال توقف است: در صورت وجود، نقدینگی {symbols} خود را برداشت کرده و دارایی‌های خود را تا ۱۰ اوت ۲۰۲۶ منتقل کنید.",
           "link": "اطلاعات بیشتر"
         },
         "fr": {
-          "header": "Le pont BitFrost (Int3face) prend fin : retirez votre liquidité {symbols} et transférez vos actifs avant le 12 août 2026.",
+          "header": "Le pont BitFrost (Int3face) prend fin : retirez votre liquidité {symbols} le cas échéant, puis transférez vos actifs avant le 10 août 2026.",
           "link": "En savoir plus"
         },
         "gu": {
-          "header": "BitFrost (Int3face) બ્રિજ બંધ થઈ રહ્યો છે: તમારી {symbols} લિક્વિડિટી પાછી ખેંચો અને 12 ઓગસ્ટ 2026 પહેલાં તમારી સંપત્તિ બ્રિજ કરો.",
+          "header": "BitFrost (Int3face) બ્રિજ બંધ થઈ રહ્યો છે: લાગુ પડે તો તમારી {symbols} લિક્વિડિટી પાછી ખેંચો અને 10 ઓગસ્ટ 2026 પહેલાં તમારી સંપત્તિ બ્રિજ કરો.",
           "link": "વધુ જાણો"
         },
         "hi": {
-          "header": "BitFrost (Int3face) ब्रिज बंद हो रहा है: अपनी {symbols} लिक्विडिटी निकालें और 12 अगस्त 2026 से पहले अपनी संपत्ति ब्रिज करें।",
+          "header": "BitFrost (Int3face) ब्रिज बंद हो रहा है: लागू हो तो अपनी {symbols} लिक्विडिटी निकालें और 10 अगस्त 2026 से पहले अपनी संपत्ति ब्रिज करें।",
           "link": "अधिक जानें"
         },
         "ja": {
-          "header": "BitFrost（Int3face）ブリッジはサービス終了となります。2026年8月12日までに{symbols}の流動性を引き出し、資産をブリッジしてください。",
+          "header": "BitFrost（Int3face）ブリッジはサービス終了となります。2026年8月10日までに、必要に応じて{symbols}の流動性を引き出し、資産をブリッジしてください。",
           "link": "詳細はこちら"
         },
         "ko": {
-          "header": "BitFrost(Int3face) 브리지 서비스가 종료됩니다. 2026년 8월 12일까지 {symbols} 유동성을 인출하고 자산을 브리지하세요.",
+          "header": "BitFrost(Int3face) 브리지 서비스가 종료됩니다. 2026년 8월 10일까지 해당되는 경우 {symbols} 유동성을 인출하고 자산을 브리지하세요.",
           "link": "자세히 보기"
         },
         "pl": {
-          "header": "Most BitFrost (Int3face) jest wycofywany: wycofaj płynność {symbols} i przenieś swoje aktywa do 12 sierpnia 2026 r.",
+          "header": "Most BitFrost (Int3face) jest wycofywany: w razie potrzeby wycofaj płynność {symbols} i przenieś swoje aktywa do 10 sierpnia 2026 r.",
           "link": "Dowiedz się więcej"
         },
         "pt-br": {
-          "header": "A ponte BitFrost (Int3face) está sendo encerrada: retire sua liquidez de {symbols} e transfira seus ativos até 12 de agosto de 2026.",
+          "header": "A ponte BitFrost (Int3face) está sendo encerrada: retire sua liquidez de {symbols}, se aplicável, e transfira seus ativos até 10 de agosto de 2026.",
           "link": "Saiba mais"
         },
         "ro": {
-          "header": "Podul BitFrost (Int3face) se închide: retrage-ți lichiditatea {symbols} și transferă-ți activele până la 12 august 2026.",
+          "header": "Podul BitFrost (Int3face) se închide: retrage-ți lichiditatea {symbols} dacă este cazul și transferă-ți activele până la 10 august 2026.",
           "link": "Află mai multe"
         },
         "ru": {
-          "header": "Мост BitFrost (Int3face) прекращает работу: выведите ликвидность {symbols} и переведите активы до 12 августа 2026 г.",
+          "header": "Мост BitFrost (Int3face) прекращает работу: при необходимости выведите ликвидность {symbols} и переведите активы до 10 августа 2026 г.",
           "link": "Подробнее"
         },
         "tr": {
-          "header": "BitFrost (Int3face) köprüsü kullanımdan kaldırılıyor: {symbols} likiditenizi çekin ve varlıklarınızı 12 Ağustos 2026'ya kadar köprüden geçirin.",
+          "header": "BitFrost (Int3face) köprüsü kullanımdan kaldırılıyor: varsa {symbols} likiditenizi çekin ve varlıklarınızı 10 Ağustos 2026'ya kadar köprüden geçirin.",
           "link": "Daha fazla bilgi"
         },
         "zh-cn": {
-          "header": "BitFrost（Int3face）跨链桥即将停止服务：请在2026年8月12日前提取您的 {symbols} 流动性并将资产跨链转出。",
+          "header": "BitFrost（Int3face）跨链桥即将停止服务：请在2026年8月10日前提取您的 {symbols} 流动性（如有）并将资产跨链转出。",
           "link": "了解更多"
         },
         "zh-hk": {
-          "header": "BitFrost（Int3face）跨鏈橋即將停止服務：請於2026年8月12日前提取您的 {symbols} 流動性並將資產跨鏈轉出。",
+          "header": "BitFrost（Int3face）跨鏈橋即將停止服務：請於2026年8月10日前提取您的 {symbols} 流動性（如有）並將資產跨鏈轉出。",
           "link": "了解更多"
         },
         "zh-tw": {
-          "header": "BitFrost（Int3face）跨鏈橋即將停止服務：請於2026年8月12日前提取您的 {symbols} 流動性並將資產跨鏈轉出。",
+          "header": "BitFrost（Int3face）跨鏈橋即將停止服務：請於2026年8月10日前提取您的 {symbols} 流動性（如有）並將資產跨鏈轉出。",
           "link": "了解更多"
         }
       }

--- a/cms/asset-alerts.json
+++ b/cms/asset-alerts.json
@@ -13,7 +13,12 @@
         "ibc/013DE940BE791C79142EAD4DF071E1ED280DFEAB8A9DCB5932A4603A74C25CBB",
         "ibc/2C5CB5DB3D86F64FDE6155A3A94D7543A126DA55490309EEDF59A0765873DA1C",
         "ibc/51BFF64A432CBBA08A1ED95609BF0255EC4BBF699BFCDFF267F66CCD664CA350",
-        "ibc/18A91A3DDFD9776A247AE1B4B3298D754D1627B85F288DCEA473B7239F7B7A0E"
+        "ibc/18A91A3DDFD9776A247AE1B4B3298D754D1627B85F288DCEA473B7239F7B7A0E",
+        "factory/osmo1cranx3twqxfrgeqvgsu262gy54vafpc9xap6scye99v244zl970s7kw2sz/alloyed/allBCH",
+        "factory/osmo1csp8fk353hnq2tmulklecxpex43qmjvrkxjcsh4c3eqcw2vjcslq5jls9v/alloyed/allLTC",
+        "factory/osmo10nu66efsxxkdgh70xs8xur9mygrg79m5ht7zcmzsrdzxkhz7hpssz9hg9k/alloyed/allPENGU",
+        "factory/osmo1524q4dt7ckx25daydfd0ya0hyu6t26ch5509nvmxm4gcvuhk0fvs8qzl5q/alloyed/allTRUMP",
+        "factory/osmo1twk0c4kcwnhkyn6pzxe0qsk6a3nrye2w2sy309d60sljfysugagsd7e3mn/alloyed/allZEC"
       ],
       "banner": {
         "enTextOrLocalizationPath": "header",

--- a/schemas/asset-alerts.schema.json
+++ b/schemas/asset-alerts.schema.json
@@ -71,7 +71,16 @@
             "required": ["enTextOrLocalizationPath", "localStorageKey"]
           },
           "localization": {
-            "type": "object"
+            "type": "object",
+            "$comment": "Locale code -> object of localization keys (referenced by enTextOrLocalizationPath / enTextOrLocalizationKey) to translated strings.",
+            "additionalProperties": {
+              "type": "object",
+              "minProperties": 1,
+              "additionalProperties": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
           }
         },
         "required": ["denoms", "banner", "localization"]

--- a/schemas/asset-alerts.schema.json
+++ b/schemas/asset-alerts.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "alerts": {
+      "type": "array",
+      "$comment": "Urgent, denom-gated alerts (e.g. a bridge or protocol sunsetting). Each alert is shown, on every page, only to wallets holding one of its denoms anywhere on Osmosis (bank balances, staked, in-locks, unclaimed rewards, or pooled). Matching is strict exact-denom: alloys are not decomposed into constituents, so to alert alloy holders the alloy denom must be listed explicitly.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "denoms": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "$comment": "Minimal denoms that trigger this alert when held, e.g. ibc/HASH or factory/... . Never symbols."
+          },
+          "banner": {
+            "type": "object",
+            "properties": {
+              "localStorageKey": {
+                "type": "string",
+                "$comment": "Persists dismissal. Must be unique per alert."
+              },
+              "enTextOrLocalizationPath": {
+                "type": "string",
+                "$comment": "English text or key into the localization block. May contain a {symbols} placeholder, replaced with the display symbols of the held assets that triggered the alert, e.g. \"DOGE.int3, LTC.int3\"."
+              },
+              "link": {
+                "type": "object",
+                "properties": {
+                  "enTextOrLocalizationKey": {
+                    "type": "string",
+                    "$comment": "English text or key into the localization block."
+                  },
+                  "url": {
+                    "type": "string"
+                  },
+                  "isExternal": {
+                    "type": "boolean",
+                    "$comment": "External to Osmosis. Show disclaimer before linking out of app."
+                  }
+                },
+                "$comment": "Link with more detail on the required action.",
+                "required": ["url"]
+              },
+              "isWarning": {
+                "type": "boolean",
+                "$comment": "Use warning styling. Unlike the top announcement banner, asset alerts remain dismissible when this is set."
+              },
+              "persistent": {
+                "type": "boolean",
+                "$comment": "Cannot be dismissed. Use with caution."
+              },
+              "bg": {
+                "type": "string",
+                "$comment": "Custom background color."
+              },
+              "startDate": {
+                "type": "string",
+                "format": "date-time",
+                "$comment": "ISO 8601 date-time string. Alert will not show until this date."
+              },
+              "endDate": {
+                "type": "string",
+                "format": "date-time",
+                "$comment": "ISO 8601 date-time string. Alert will not show after this date."
+              }
+            },
+            "required": ["enTextOrLocalizationPath", "localStorageKey"]
+          },
+          "localization": {
+            "type": "object"
+          }
+        },
+        "required": ["denoms", "banner", "localization"]
+      }
+    }
+  },
+  "required": ["alerts"]
+}


### PR DESCRIPTION
## What

New `cms/asset-alerts.json` + schema: **denom-gated asset alerts** for the frontend feature in osmosis-labs/osmosis-frontend#4424. Each alert is a top banner shown only to connected wallets holding one of its `denoms` anywhere on Osmosis (bank, staked, in-locks, unclaimed rewards, or pooled), with per-alert localStorage dismissal, `startDate`/`endDate` windows, full localization, and an optional `{symbols}` placeholder that renders the holder's matched asset symbols.

Validation: the existing ajv CI spec picks the file up automatically; the localization block is schema-constrained (locale entries must be non-empty objects of non-empty strings), and a new vitest spec asserts `endDate > startDate` per alert (cross-field checks aren't expressible in draft-07).

## First entry: BitFrost (Int3face) bridge sunset

Announcement: https://x.com/_Bitfrost_/status/2082826447073300616 — withdrawal period ends **2026-08-10**; holders should withdraw BitFrost pool liquidity if they have any, then bridge assets out.

16 denoms, matched by exact minimal denom:

- All 11 int3-bridged assets: INT3 plus the DOGE, BTC, BCH, LTC, TON, SOL, XRP, PENGU, TRUMP, ZEC variants.
- The 5 **int3-only alloys**: allBCH, allLTC, allPENGU, allTRUMP, allZEC. Verified onchain that each is 100% backed by its int3 variant (contract backing equals alloy supply, no other constituents), so their holders must redeem to the int3 asset and bridge out before the deadline just like direct holders.
- The multi-variant alloys (allBTC, allDOGE, allSOL, allTON, allXRP) currently hold **zero** int3 backing (drained/migrated to nBTC, cbDOGE, SOL.wh, TON.orai, XRP.xrplevm respectively) and are deliberately not flagged.

Live 2026-07-30 → 2026-08-10T23:59:59Z, warning styling, dismissible, links to the announcement. 17-locale localization block matching the top-announcement-banner convention; copy says "withdraw liquidity if applicable, then bridge out" since many targeted holders have no LP position.

## Notes

- Alert matching in the frontend is strict exact-denom (alloys are never auto-expanded), which is why affected alloys are listed explicitly here.
- `isWarning` and `persistent` are deliberately independent: for asset alerts, warning is pure styling and `persistent` alone controls dismissibility, so a persistent warning is a valid configuration.
- Safe to merge before the frontend PR: rendering is gated behind the `asset-alerts` LaunchDarkly flag, off in prod until verified.